### PR TITLE
Remove the importlib-resources dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v 1.1.5
+- Remove the importlib-resources dependency
+
 # v 1.1.4
 - Update dependencies
 

--- a/module.yml
+++ b/module.yml
@@ -1,7 +1,7 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: ip
-version: 1.1.4
+version: 1.1.5.dev1604389941
 compiler_version: 2016.5
 requires:
     std: std >= 1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 netaddr~=0.8.0
 
-importlib-resources~=3.3.0
 zipp~=3.4.0


### PR DESCRIPTION
# Description

Remove the importlib-resources dependency to resolve a version conflict with the openstack module.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [ ] ~~Code is clear and sufficiently documented~~
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [ ] ~~Correct, in line with design~~
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
