### PR TITLE
Issue/port should be int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.2.19 - ?
 
+- Make sure that ip::port is always an integer
 
 ## v1.2.18 - 2023-06-30
 

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -23,7 +23,7 @@ typedef cidr as string matching ip::is_valid_cidr(self) == true
 
 typedef protocol as string matching
     self == "tcp" or self == "udp" or self == "icmp" or self == "sctp" or self == "all"
-typedef port as number matching self >= 0 and self < 65536
+typedef port as int matching self >= 0 and self < 65536
 
 typedef cidr_v6 as string matching ip::is_valid_cidr_v6(self) == true
 typedef ip_v6 as string matching ip::is_valid_ip_v6(self) == true


### PR DESCRIPTION
# Description

While investigating a bug in yaml loading of integers, I realized that the `ip::port` type accepts the `number` type.  I think it doesn't make sense, a port is always an `integer`.

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

