### PR TITLE
defer to std::Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v1.3.2 - ?
+- defer to std::Host and its implementations for compatibility
 
 
 ## v1.3.1 - 2023-12-06

--- a/model/_init.cf
+++ b/model/_init.cf
@@ -44,31 +44,10 @@ typedef mask as string matching ip::is_valid_netmask(self)
 
 entity Host extends std::Host:
     """
-        A host that has an ip attribute for easy ip address access in the configuration
-        model.
-
-        :attr ip: The ipaddress of this node
-        :attr remote_agent: Start the mgmt agent for this node on the server and use remote io (ssh)
-        :attr remote_user: The remote user for the remote agent to login with
-        :attr remote_port: The remote port for this remote agent to use.
+        Like std::Host, kept for backwards compatibility.
     """
-    std::ipv_any_address ip
-    bool remote_agent=false
-    string remote_user="root"
-    port remote_port=22
 end
 implement Host using std::hostDefaults
-
-implementation agentConfig for std::HostConfig:
-    std::AgentConfig(
-        autostart=true,
-        agentname=host.name,
-        uri=std::template("ip/host_uri.j2"),
-        provides=host,
-    )
-end
-
-implement std::HostConfig using agentConfig when host.ip is defined and host.remote_agent
 
 entity IP:
     """

--- a/module.yml
+++ b/module.yml
@@ -3,4 +3,6 @@ license: Apache 2.0
 name: ip
 version: 1.3.2.dev0
 compiler_version: 2016.5
+requires:
+    - std>=4.5
 deprecated: true


### PR DESCRIPTION
Now that std defines these fields and implementations they are no longer required here, if we have that version of std. Given that for attribute inheritance compatibility, we need the typedefs from std anyway, we must just depend on that version of the std module.

Compatibility graph:
- `ip<1.3.2` compatible only with `std<4.5 (can't be made explicit in a constraint)
- `ip>=1.3.2` compatible only with `std>=4.5` (enforced by constraint)

I don't see any way to make this range broader unless we wait till iso8. I think the range is acceptable as is: either update none of the modules or update all of them.