### PR TITLE
made some tests more robust in error message check

### DIFF
--- a/tests/test_ip_types.py
+++ b/tests/test_ip_types.py
@@ -139,7 +139,7 @@ def test_is_valid_ip_in_model_invalid_ip(project):
 
         ip::is_valid_ip(true)
     """
-    assert_compilation_error(project, model, "Invalid value 'True', expected String")
+    assert_compilation_error(project, model, "Invalid value 'True', expected (S|s)tring")
 
 
 def test_is_valid_cidr_v10(project):
@@ -161,7 +161,7 @@ def test_test_is_valid_cidr_v10_in_model_invalid_ip(project):
 
         ip::is_valid_cidr_v10(true)
     """
-    assert_compilation_error(project, model, "Invalid value 'True', expected String")
+    assert_compilation_error(project, model, "Invalid value 'True', expected (S|s)tring")
 
 
 def test_is_valid_ip_v10(project):
@@ -181,7 +181,7 @@ def test_test_is_valid_ip_v10_in_model_invalid_ip(project):
 
         ip::is_valid_ip_v10(true)
     """
-    assert_compilation_error(project, model, "Invalid value 'True', expected String")
+    assert_compilation_error(project, model, "Invalid value 'True', expected (S|s)tring")
 
 
 def test_is_valid_netmask(project):


### PR DESCRIPTION
# Description

Made some assertions more robust. These were now failing in the module set tests. We had to make a similar change in `tests/test_ip.py` a while ago. I'm honestly not sure why this one wasn't required back then.

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

